### PR TITLE
Update/screen calls

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -66,7 +66,7 @@ describe(@"Mixpanel Integration", ^{
     
     it(@"screen with consolidatedPageCalls", ^{
         [integration setSettings:@{
-            @"consolidatedPageCalls" : @true
+            @"consolidatedPageCalls" : @1
         }];
         [integration screen:[SEGPayloadBuilder screen:@"Home"]];
         

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -10,7 +10,7 @@
 
 #import "SEGPayloadBuilder.h"
 
-SpecBegin(InitialSpecs);
+SpecBegin(InitialSpecs)
 
 describe(@"Mixpanel Integration", ^{
     __block SEGMixpanelIntegration *integration;
@@ -62,6 +62,15 @@ describe(@"Mixpanel Integration", ^{
         [integration screen:[SEGPayloadBuilder screen:@"Home"]];
 
         [verify(mixpanel) track:@"Viewed Home Screen" properties:@{}];
+    });
+    
+    it(@"screen with consolidatedPageCalls", ^{
+        [integration setSettings:@{
+            @"consolidatedPageCalls" : @true
+        }];
+        [integration screen:[SEGPayloadBuilder screen:@"Home"]];
+        
+        [verify(mixpanel) track:@"Loaded a Screen" properties:@{@"name": @"Home"}];
     });
 
     it(@"identify", ^{

--- a/Pod/Classes/SEGMixpanelIntegration.m
+++ b/Pod/Classes/SEGMixpanelIntegration.m
@@ -111,28 +111,28 @@
             [payloadProps setValue:payload.name forKey:@"name"];
         }
         [self realTrack:event properties:payloadProps];
-        SEGLog(@"[[Mixpanel sharedInstance] track:Loaded a Screen properties:%@]", payloadProps);
+        SEGLog(@"[[Mixpanel sharedInstance] track:'Loaded a Screen' properties:%@]", payloadProps);
         return;
     }
     
     if ([(NSNumber *)[self.settings objectForKey:@"trackAllPages"] boolValue]) {
         NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", payload.name];
         [self realTrack:event properties:payload.properties];
-        SEGLog(@"[[Mixpanel sharedInstance] track:Viewed %@ Screen properties:%@]", payload.name, payload.properties);
+        SEGLog(@"[[Mixpanel sharedInstance] track:'Viewed %@ Screen' properties:%@]", payload.name, payload.properties);
         return;
     }
 
     if ([(NSNumber *)[self.settings objectForKey:@"trackNamedPages"] boolValue] && payload.name) {
         NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", payload.name];
         [self realTrack:event properties:payload.properties];
-        SEGLog(@"[[Mixpanel sharedInstance] track:Viewed %@ Screen properties:%@]", payload.name, payload.properties);
+        SEGLog(@"[[Mixpanel sharedInstance] track:'Viewed %@ Screen' properties:%@]", payload.name, payload.properties);
         return;
     }
 
     NSString *category = [payload.properties objectForKey:@"category"];
     if ([(NSNumber *)[self.settings objectForKey:@"trackCategorizedPages"] boolValue] && category) {
         NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", category];
-        SEGLog(@"[[Mixpanel sharedInstance] track:Viewed %@ Screen properties:%@]", category, payload.properties);
+        SEGLog(@"[[Mixpanel sharedInstance] track:'Viewed %@ Screen' properties:%@]", category, payload.properties);
         [self realTrack:event properties:payload.properties];
     }
 }

--- a/Pod/Classes/SEGMixpanelIntegration.m
+++ b/Pod/Classes/SEGMixpanelIntegration.m
@@ -104,6 +104,16 @@
 
 - (void)screen:(SEGScreenPayload *)payload
 {
+    if ([(NSNumber *)[self.settings objectForKey:@"consolidatedPageCalls"] boolValue]) {
+        NSMutableDictionary *payloadProps = [NSMutableDictionary dictionaryWithDictionary:payload.properties];
+        NSString *event = [[NSString alloc] initWithFormat:@"Loaded a Screen"];
+        if (payload.name) {
+            [payloadProps setValue:payload.name forKey:@"name"];
+        }
+        [self realTrack:event properties:payloadProps];
+        return;
+    }
+    
     if ([(NSNumber *)[self.settings objectForKey:@"trackAllPages"] boolValue]) {
         NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", payload.name];
         [self realTrack:event properties:payload.properties];

--- a/Pod/Classes/SEGMixpanelIntegration.m
+++ b/Pod/Classes/SEGMixpanelIntegration.m
@@ -111,24 +111,28 @@
             [payloadProps setValue:payload.name forKey:@"name"];
         }
         [self realTrack:event properties:payloadProps];
+        SEGLog(@"[[Mixpanel sharedInstance] track:Loaded a Screen properties:%@]", payloadProps);
         return;
     }
     
     if ([(NSNumber *)[self.settings objectForKey:@"trackAllPages"] boolValue]) {
         NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", payload.name];
         [self realTrack:event properties:payload.properties];
+        SEGLog(@"[[Mixpanel sharedInstance] track:Viewed %@ Screen properties:%@]", payload.name, payload.properties);
         return;
     }
 
     if ([(NSNumber *)[self.settings objectForKey:@"trackNamedPages"] boolValue] && payload.name) {
         NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", payload.name];
         [self realTrack:event properties:payload.properties];
+        SEGLog(@"[[Mixpanel sharedInstance] track:Viewed %@ Screen properties:%@]", payload.name, payload.properties);
         return;
     }
 
     NSString *category = [payload.properties objectForKey:@"category"];
     if ([(NSNumber *)[self.settings objectForKey:@"trackCategorizedPages"] boolValue] && category) {
         NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", category];
+        SEGLog(@"[[Mixpanel sharedInstance] track:Viewed %@ Screen properties:%@]", category, payload.properties);
         [self realTrack:event properties:payload.properties];
     }
 }


### PR DESCRIPTION
Update Screen Method and Tests to support consolidatedPageCalls setting cc @f2prateek 

This will allow us to migrate users to Mixpanel's suggested way of tracking Pageviews, with a single consolidated event that can be differentiated upon by the included properties