### PR TITLE
adds instance with launch-options for push notification tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 
-osx_image: xcode7.1
+osx_image: xcode7.3
 
 before_install:
   - gem install cocoapods

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,11 +3,11 @@ use_frameworks!
 
 platform :ios, '8.0'
 
-target 'Segment-Mixpanel_Example', :exclusive => true do
+target 'Segment-Mixpanel_Example' do
   pod "Segment-Mixpanel", :path => "../"
 end
 
-target 'Segment-Mixpanel_Tests', :exclusive => true do
+target 'Segment-Mixpanel_Tests' do
   pod "Segment-Mixpanel", :path => "../"
 
   pod 'OCMockito'

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Pod/Classes/SEGMixpanelIntegration.h
+++ b/Pod/Classes/SEGMixpanelIntegration.h
@@ -8,10 +8,8 @@
 @property (nonatomic, strong) NSDictionary *settings;
 @property (nonatomic, strong) Mixpanel *mixpanel;
 
-- (instancetype)initWithSettings:(NSDictionary *)settings;
-
 - (instancetype)initWithSettings:(NSDictionary *)settings andMixpanel:(Mixpanel *)mixpanel;
 
-- (instancetype)initWithSettings:(NSDictionary *)settings launchOptions:(NSDictionary *)launchOptions;
+- (instancetype)initWithSettings:(NSDictionary *)settings andLaunchOptions:(NSDictionary *)launchOptions;
 
 @end

--- a/Pod/Classes/SEGMixpanelIntegration.h
+++ b/Pod/Classes/SEGMixpanelIntegration.h
@@ -12,6 +12,6 @@
 
 - (instancetype)initWithSettings:(NSDictionary *)settings andMixpanel:(Mixpanel *)mixpanel;
 
--(instancetype)initWithSettings:(NSDictionary *)settings launchOptions:(NSDictionary *)launchOptions;
+- (instancetype)initWithSettings:(NSDictionary *)settings launchOptions:(NSDictionary *)launchOptions;
 
 @end

--- a/Pod/Classes/SEGMixpanelIntegration.h
+++ b/Pod/Classes/SEGMixpanelIntegration.h
@@ -12,4 +12,6 @@
 
 - (instancetype)initWithSettings:(NSDictionary *)settings andMixpanel:(Mixpanel *)mixpanel;
 
+-(instancetype)initWithSettings:(NSDictionary *)settings launchOptions:(NSDictionary *)launchOptions;
+
 @end

--- a/Pod/Classes/SEGMixpanelIntegration.m
+++ b/Pod/Classes/SEGMixpanelIntegration.m
@@ -4,15 +4,6 @@
 
 @implementation SEGMixpanelIntegration
 
-- (instancetype)initWithSettings:(NSDictionary *)settings
-{
-    if (self = [super init]) {
-        self.settings = settings;
-        NSString *token = [self.settings objectForKey:@"token"];
-        self.mixpanel = [Mixpanel sharedInstanceWithToken:token];
-    }
-    return self;
-}
 
 - (instancetype)initWithSettings:(NSDictionary *)settings andMixpanel:(Mixpanel *)mixpanel
 {
@@ -23,13 +14,12 @@
     return self;
 }
 
--(instancetype)initWithSettings:(NSDictionary *)settings launchOptions:(NSDictionary *)launchOptions
+-(instancetype)initWithSettings:(NSDictionary *)settings andLaunchOptions:(NSDictionary *)launchOptions
 {
 
     if (self= [super init]) {
         self.settings = settings;
         NSString *token = [self.settings objectForKey:@"token"];
-        // Push open tracking requires you to initialize Mixpanel with launch options
         self.mixpanel = [Mixpanel sharedInstanceWithToken: token launchOptions:launchOptions];
     }
     return self;

--- a/Pod/Classes/SEGMixpanelIntegration.m
+++ b/Pod/Classes/SEGMixpanelIntegration.m
@@ -23,6 +23,18 @@
     return self;
 }
 
+-(instancetype)initWithSettings:(NSDictionary *)settings launchOptions:(NSDictionary *)launchOptions
+{
+
+    if (self= [super init]) {
+        self.settings = settings;
+        NSString *token = [self.settings objectForKey:@"token"];
+        // Push open tracking requires you to initialize Mixpanel with launch options
+        self.mixpanel = [Mixpanel sharedInstanceWithToken: token launchOptions:launchOptions];
+    }
+    return self;
+}
+
 + (NSDictionary *)map:(NSDictionary *)dictionary withMap:(NSDictionary *)map
 {
     NSMutableDictionary *mapped = [NSMutableDictionary dictionaryWithDictionary:dictionary];

--- a/Pod/Classes/SEGMixpanelIntegrationFactory.h
+++ b/Pod/Classes/SEGMixpanelIntegrationFactory.h
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGIntegrationFactory.h>
 
-
 @interface SEGMixpanelIntegrationFactory : NSObject <SEGIntegrationFactory>
-
 + (instancetype)instance;
 + (instancetype)instanceWithLaunchOptions: (NSString *)token launchOptions:(NSDictionary *)launchOptions;
+@property NSDictionary *launchOptions;
 
 @end
+

--- a/Pod/Classes/SEGMixpanelIntegrationFactory.h
+++ b/Pod/Classes/SEGMixpanelIntegrationFactory.h
@@ -3,7 +3,7 @@
 
 @interface SEGMixpanelIntegrationFactory : NSObject <SEGIntegrationFactory>
 + (instancetype)instance;
-+ (instancetype)instanceWithLaunchOptions: (NSString *)token launchOptions:(NSDictionary *)launchOptions;
++ (instancetype)createWithLaunchOptions: (NSString *)token launchOptions:(NSDictionary *)launchOptions;
 @property NSDictionary *launchOptions;
 
 @end

--- a/Pod/Classes/SEGMixpanelIntegrationFactory.h
+++ b/Pod/Classes/SEGMixpanelIntegrationFactory.h
@@ -5,5 +5,6 @@
 @interface SEGMixpanelIntegrationFactory : NSObject <SEGIntegrationFactory>
 
 + (instancetype)instance;
++ (instancetype)instanceWithLaunchOptions: (NSString *)token launchOptions:(NSDictionary *)launchOptions;
 
 @end

--- a/Pod/Classes/SEGMixpanelIntegrationFactory.h
+++ b/Pod/Classes/SEGMixpanelIntegrationFactory.h
@@ -2,8 +2,10 @@
 #import <Analytics/SEGIntegrationFactory.h>
 
 @interface SEGMixpanelIntegrationFactory : NSObject <SEGIntegrationFactory>
+
 + (instancetype)instance;
-+ (instancetype)createWithLaunchOptions: (NSString *)token launchOptions:(NSDictionary *)launchOptions;
++ (instancetype)createWithLaunchOptions:(NSString *)token launchOptions:(NSDictionary *)launchOptions;
+
 @property NSDictionary *launchOptions;
 
 @end

--- a/Pod/Classes/SEGMixpanelIntegrationFactory.m
+++ b/Pod/Classes/SEGMixpanelIntegrationFactory.m
@@ -34,8 +34,7 @@
     static dispatch_once_t once;
     static SEGMixpanelIntegrationFactory *sharedInstance;
     dispatch_once(&once, ^{
-        [Mixpanel sharedInstanceWithToken:token launchOptions:launchOptions];
-        sharedInstance = [[self alloc] init];
+        sharedInstance = [[self alloc] initWithLaunchOptions:launchOptions];
     });
     return sharedInstance;
     
@@ -44,7 +43,7 @@
 
 - (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics 
 {
-    return [[SEGMixpanelIntegration alloc] initWithSettings:settings launchOptions:_launchOptions];
+    return [[SEGMixpanelIntegration alloc] initWithSettings:settings];
 }
 
 

--- a/Pod/Classes/SEGMixpanelIntegrationFactory.m
+++ b/Pod/Classes/SEGMixpanelIntegrationFactory.m
@@ -9,18 +9,12 @@
     static dispatch_once_t once;
     static SEGMixpanelIntegrationFactory *sharedInstance;
     dispatch_once(&once, ^{
-        sharedInstance = [[self alloc] init];
+        sharedInstance = [[self alloc] initWithLaunchOptions:nil];
     });
     return sharedInstance;
 }
 
-- (instancetype)init
-{
-    self = [super init];
-    return self;
-}
-
-- (instancetype)initWithLaunchOptions: (NSDictionary *)launchOptions
+- (instancetype)initWithLaunchOptions:(NSDictionary *)launchOptions
 {
     if (self = [super init]) {
         self.launchOptions = launchOptions;
@@ -29,14 +23,14 @@
 }
 
 
-+ (instancetype)createWithLaunchOptions: (NSString *)token launchOptions:(NSDictionary *)launchOptions
++ (instancetype)createWithLaunchOptions:(NSString *)token launchOptions:(NSDictionary *)launchOptions
 {
-    return [[self alloc] initWithLaunchOptions:launchOptions];;
+    return [[self alloc] initWithLaunchOptions:launchOptions];
 }
 
 - (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics 
 {
-    return [[SEGMixpanelIntegration alloc] initWithSettings:settings];
+    return [[SEGMixpanelIntegration alloc] initWithSettings:settings andLaunchOptions:self.launchOptions];
 }
 
 

--- a/Pod/Classes/SEGMixpanelIntegrationFactory.m
+++ b/Pod/Classes/SEGMixpanelIntegrationFactory.m
@@ -20,6 +20,14 @@
     return self;
 }
 
+- (instancetype)initWithLaunchOptions: (NSDictionary *)launchOptions
+{
+    if (self = [super init]) {
+        self.launchOptions = launchOptions;
+    }
+    return self;
+}
+
 
 + (instancetype)instanceWithLaunchOptions: (NSString *)token launchOptions:(NSDictionary *)launchOptions
 {
@@ -33,9 +41,10 @@
     
 }
 
-- (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics
+
+- (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics 
 {
-    return [[SEGMixpanelIntegration alloc] initWithSettings:settings];
+    return [[SEGMixpanelIntegration alloc] initWithSettings:settings launchOptions:_launchOptions];
 }
 
 

--- a/Pod/Classes/SEGMixpanelIntegrationFactory.m
+++ b/Pod/Classes/SEGMixpanelIntegrationFactory.m
@@ -20,10 +20,24 @@
     return self;
 }
 
+
++ (instancetype)instanceWithLaunchOptions: (NSString *)token launchOptions:(NSDictionary *)launchOptions
+{
+    static dispatch_once_t once;
+    static SEGMixpanelIntegrationFactory *sharedInstance;
+    dispatch_once(&once, ^{
+        [Mixpanel sharedInstanceWithToken:token launchOptions:launchOptions];
+        sharedInstance = [[self alloc] init];
+    });
+    return sharedInstance;
+    
+}
+
 - (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics
 {
     return [[SEGMixpanelIntegration alloc] initWithSettings:settings];
 }
+
 
 - (NSString *)key
 {

--- a/Pod/Classes/SEGMixpanelIntegrationFactory.m
+++ b/Pod/Classes/SEGMixpanelIntegrationFactory.m
@@ -29,17 +29,10 @@
 }
 
 
-+ (instancetype)instanceWithLaunchOptions: (NSString *)token launchOptions:(NSDictionary *)launchOptions
++ (instancetype)createWithLaunchOptions: (NSString *)token launchOptions:(NSDictionary *)launchOptions
 {
-    static dispatch_once_t once;
-    static SEGMixpanelIntegrationFactory *sharedInstance;
-    dispatch_once(&once, ^{
-        sharedInstance = [[self alloc] initWithLaunchOptions:launchOptions];
-    });
-    return sharedInstance;
-    
+    return [[self alloc] initWithLaunchOptions:launchOptions];;
 }
-
 
 - (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics 
 {


### PR DESCRIPTION
To add push open tracking, Mixpanel requires that on initialization Mixpanel is launched with options, meaning Segment needs  an instance which includes this `launchOptions` parameter:

```[Mixpanel sharedInstanceWithToken:MIXPANEL_TOKEN launchOptions:launchOptions];```

I will need a ton of feedback on this, as I'm not too familiar with building out this functionality. 

[EPD-307](https://segment.atlassian.net/browse/EPD-307)
[Tracking push notification open rate](https://mixpanel.com/help/questions/articles/how-do-i-track-push-notification-open-rate)

@hankim813 @anoonan 