### PR TITLE
Allow Non-modular Includes in Framework Modules

### DIFF
--- a/Example/Segment-Mixpanel.xcodeproj/project.pbxproj
+++ b/Example/Segment-Mixpanel.xcodeproj/project.pbxproj
@@ -548,6 +548,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Segment-Mixpanel/Segment-Mixpanel-Prefix.pch";
 				INFOPLIST_FILE = "Segment-Mixpanel/Segment-Mixpanel-Info.plist";
@@ -564,6 +565,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Segment-Mixpanel/Segment-Mixpanel-Prefix.pch";
 				INFOPLIST_FILE = "Segment-Mixpanel/Segment-Mixpanel-Info.plist";
@@ -579,6 +581,7 @@
 			baseConfigurationReference = 2686DAE53EB1FC85DD97261B /* Pods-Segment-Mixpanel_Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Tests/Tests-Prefix.pch";
@@ -598,6 +601,7 @@
 			baseConfigurationReference = 82DB54EF8811654DC7D66E24 /* Pods-Segment-Mixpanel_Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Tests/Tests-Prefix.pch";

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 XCPRETTY := xcpretty -c && exit ${PIPESTATUS[0]}
 
 SDK ?= "iphonesimulator"
-DESTINATION ?= "platform=iOS Simulator,name=iPhone 5"
+DESTINATION ?= "platform=iOS Simulator,name=iPhone 6"
 PROJECT := Segment-Mixpanel
 XC_ARGS := -scheme $(PROJECT)-Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
 


### PR DESCRIPTION

`xcodebuild test -scheme Segment-Mixpanel-Example -workspace Example/Segment-Mixpanel.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 6'`

Passes after setting `Allow Non-modular Includes in Framework Modules` to YES

Original error:

```

Testing failed:
	Include of non-modular header inside framework module 'Mixpanel': '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator10.3.sdk/usr/include/CommonCrypto/CommonDigest.h'
	Could not build module 'Mixpanel'
	Could not build module 'Mixpanel'
** TEST FAILED **

```

With changes:

```
objc[10601]: Class SEGPayloadBuilder is implemented in both /Users/ladannasserian/Library/Developer/CoreSimulator/Devices/09C02AC8-3A97-4AE2-A530-4043F7552062/data/Containers/Bundle/Application/7807FA5A-7DB9-4666-B1D1-22EB6E59BFDB/Segment-Mixpanel_Example.app/Segment-Mixpanel_Example (0x105cc9270) and /Users/ladannasserian/Library/Developer/Xcode/DerivedData/Segment-Mixpanel-gntuaivkjulcxlcbutpjdzkzdagq/Build/Products/Debug-iphonesimulator/Segment-Mixpanel_Example.app/PlugIns/Segment-Mixpanel_Tests.xctest/Segment-Mixpanel_Tests (0x115f04f98). One of the two will be used. Which one is undefined.
Test Suite 'All tests' started at 2017-10-19 13:47:55.115
Test Suite 'Specta.framework' started at 2017-10-19 13:47:55.115
Test Suite 'Specta.framework' passed at 2017-10-19 13:47:55.115.
	 Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'Segment-Mixpanel_Tests.xctest' started at 2017-10-19 13:47:55.116
Test Suite 'InitialSpecsSpec' started at 2017-10-19 13:47:55.116
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__track]' started.
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__track]' passed (0.020 seconds).
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__track_with_properties]' started.
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__track_with_properties]' passed (0.003 seconds).
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__track_with_people]' started.
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__track_with_people]' passed (0.003 seconds).
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__screen]' started.
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__screen]' passed (0.002 seconds).
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__screen_with_consolidatedPageCalls]' started.
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__screen_with_consolidatedPageCalls]' passed (0.002 seconds).
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__identify]' started.
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__identify]' passed (0.003 seconds).
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__identify_with_traits]' started.
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__identify_with_traits]' passed (0.004 seconds).
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__alias]' started.
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__alias]' passed (0.003 seconds).
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__flush]' started.
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__flush]' passed (0.002 seconds).
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__reset]' started.
Test Case '-[InitialSpecsSpec test_Mixpanel_Integration__reset]' passed (0.003 seconds).
Test Suite 'InitialSpecsSpec' passed at 2017-10-19 13:47:55.163.
	 Executed 10 tests, with 0 failures (0 unexpected) in 0.044 (0.047) seconds
Test Suite 'Segment-Mixpanel_Tests.xctest' passed at 2017-10-19 13:47:55.164.
	 Executed 10 tests, with 0 failures (0 unexpected) in 0.044 (0.048) seconds
Test Suite 'All tests' passed at 2017-10-19 13:47:55.164.
	 Executed 10 tests, with 0 failures (0 unexpected) in 0.044 (0.049) seconds
** TEST SUCCEEDED **

```