### PR TITLE
Increment updates

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -57,6 +57,19 @@ describe(@"Mixpanel Integration", ^{
         }];
         [verify(mixpanelPeople) trackCharge:@19.99];
     });
+    
+    it(@"track with property increments", ^{
+        [integration setSettings:@{
+            @"people" : @1,
+            @"propIncrements" : @[@"revenue"]
+        }];
+        [integration track:[SEGPayloadBuilder track:@"Purchased Item" withProperties:@{
+            @"revenue" : @19.99
+        }]];
+        [verify(mixpanel) track:@"Purchased Item" properties:@{
+            @"revenue" : @19.99
+        }];
+    });    
 
     it(@"screen", ^{
         [integration screen:[SEGPayloadBuilder screen:@"Home"]];

--- a/Pod/Classes/SEGMixpanelIntegration.m
+++ b/Pod/Classes/SEGMixpanelIntegration.m
@@ -173,7 +173,7 @@
         return;
     }
     
-    // Handle property increments
+    // Increment properties that are listed in the Mixpanel integration settings
     [self incrementProperties:properties];    
 
     // Extract the revenue from the properties passed in to us.
@@ -233,7 +233,6 @@
         for (NSString *property in properties) {
             if ([property caseInsensitiveCompare:propIncrement] == NSOrderedSame) {
                 [[self.mixpanel people] increment:property by:[properties objectForKey:property]];
-                
                 SEGLog(@"[[[Mixpanel sharedInstance] people] increment:%@ by:%@]", property, [properties objectForKey:property]);
             }
         }

--- a/Pod/Classes/SEGMixpanelIntegration.m
+++ b/Pod/Classes/SEGMixpanelIntegration.m
@@ -225,7 +225,7 @@
     return NO;
 }
 
-// An internal utility method that checks the settings to see if this event should be incremented in Mixpanel.
+// An internal utility method that checks if properties need to be incremented and performs the increment.
 - (void)incrementProperties:(NSDictionary *)properties
 {
     NSArray *propIncrements = [self.settings objectForKey:@"propIncrements"];
@@ -234,7 +234,7 @@
             if ([property caseInsensitiveCompare:propIncrement] == NSOrderedSame) {
                 [[self.mixpanel people] increment:property by:[properties objectForKey:property]];
                 
-                SEGLog(@"[[[Mixpanel sharedInstance] people] increment:%@ by:1]", property);
+                SEGLog(@"[[[Mixpanel sharedInstance] people] increment:%@ by:%@]", property, [properties objectForKey:property]);
             }
         }
     }

--- a/Pod/Classes/SEGMixpanelIntegration.m
+++ b/Pod/Classes/SEGMixpanelIntegration.m
@@ -172,6 +172,9 @@
     if (![self peopleEnabled]) {
         return;
     }
+    
+    // Handle property increments
+    [self incrementProperties:properties];    
 
     // Extract the revenue from the properties passed in to us.
     NSNumber *revenue = [SEGMixpanelIntegration extractRevenue:properties withKey:@"revenue"];
@@ -213,13 +216,28 @@
 // An internal utility method that checks the settings to see if this event should be incremented in Mixpanel.
 - (BOOL)eventShouldIncrement:(NSString *)event
 {
-    NSArray *increments = [self.settings objectForKey:@"increments"];
+    NSArray *increments = [self.settings objectForKey:@"eventIncrements"];
     for (NSString *increment in increments) {
         if ([event caseInsensitiveCompare:increment] == NSOrderedSame) {
             return YES;
         }
     }
     return NO;
+}
+
+// An internal utility method that checks the settings to see if this event should be incremented in Mixpanel.
+- (void)incrementProperties:(NSDictionary *)properties
+{
+    NSArray *propIncrements = [self.settings objectForKey:@"propIncrements"];
+    for (NSString *propIncrement in propIncrements) {
+        for (NSString *property in properties) {
+            if ([property caseInsensitiveCompare:propIncrement] == NSOrderedSame) {
+                [[self.mixpanel people] increment:property by:[properties objectForKey:property]];
+                
+                SEGLog(@"[[[Mixpanel sharedInstance] people] increment:%@ by:1]", property);
+            }
+        }
+    }
 }
 
 // Return true the project has the People feature enabled.


### PR DESCRIPTION
This addresses the issue that Capital One raised ([JIRA](https://segment.atlassian.net/browse/PLATFORM-2342)). In summary, our client-side Mixpanel integration (iOS/Android) currently doesn't support [Property Increments](https://segment.com/docs/destinations/mixpanel/#incrementing-properties). This fix addresses that but following the same method implemented for Event Increments, first checking the integration options and traversing through the list to fire the People Increment method that Mixpanel exposes.