### PR TITLE
Update Mixpanel to 3.5.0

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Analytics (3.2.6)
   - Expecta (1.0.3)
-  - Mixpanel (3.4.9)
+  - Mixpanel (3.5.0)
   - OCHamcrest (5.2.0)
   - OCMockito (3.0.1):
     - OCHamcrest (~> 5.1)
-  - Segment-Mixpanel (1.3.0):
+  - Segment-Mixpanel (1.4.0):
     - Analytics (~> 3.0)
-    - Mixpanel (~> 3.4.7)
+    - Mixpanel (~> 3.5.0)
   - Specta (1.0.7)
 
 DEPENDENCIES:
@@ -17,7 +17,7 @@ DEPENDENCIES:
   - Specta
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Analytics
     - Expecta
     - Mixpanel
@@ -32,12 +32,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Analytics: ad1c5bdc169866d72afdbc918084d0695010e35a
   Expecta: 9d1bff6c8b0eeee73a166a2ee898892478927a15
-  Mixpanel: 5aca6e506b34650b96dc759a208513d86650fac7
+  Mixpanel: 399997670f5452de026449f9e9ecd52eccbb9ff7
   OCHamcrest: 218dc4022a5e928a275771da70c5dbea9f859287
   OCMockito: 9eee3c61e42f7cb8aa015d66f8cc16849701d973
-  Segment-Mixpanel: 4ff970648d9c49ee0a62a32eec777346316ee7ea
+  Segment-Mixpanel: a43281d69522e04f16e64440411485ca5454807f
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 507a152874203f544f8656b6532dd0f45dd3c57d
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.1

--- a/Segment-Mixpanel.podspec
+++ b/Segment-Mixpanel.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics', '~> 3.0'
-  s.dependency 'Mixpanel', '~> 3.4.7'
+  s.dependency 'Mixpanel', '~> 3.5.0'
 end


### PR DESCRIPTION
As reported in #45 Mixpanel 3.4.x contains an iOS 13 issue (https://github.com/mixpanel/mixpanel-iphone/issues/867). To solve that I updated podspec to require 3.5.x version of Mixpanel.