### PR TITLE
DAND-61-Add support for groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,6 @@
 Change Log
 ==========
 
-Version 1.5.0 *(17th Dec, 2019)*
--------------------------------------------
-*(Upgrade Segment-Mixpanel to 3.5)*
-    
-    * [New](https://github.com/segment-integrations/analytics-ios-integration-mixpanel/pull/47): Upgrade Segment-Mixpanel to 3.5.0.
-
-    * [New] Add support for groups
-
-
 Version 1.4.0 *(12th September, 2019)*
 -------------------------------------------
 *(Upgrade Segment-Mixpanel to 3.4.7)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Change Log
 ==========
 
+Version 1.5.0 *(17th Dec, 2019)*
+-------------------------------------------
+*(Upgrade Segment-Mixpanel to 3.5)*
+    
+    * [New](https://github.com/segment-integrations/analytics-ios-integration-mixpanel/pull/47): Upgrade Segment-Mixpanel to 3.5.0.
+
+    * [New] Add support for groups
+
+
 Version 1.4.0 *(12th September, 2019)*
 -------------------------------------------
 *(Upgrade Segment-Mixpanel to 3.4.7)*

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -10,7 +10,7 @@ end
 target 'Segment-Mixpanel_Tests' do
   pod "Segment-Mixpanel", :path => "../"
 
-  pod 'OCMockito'
+  pod 'OCMockito', '~> 3.0'
   pod 'Specta'
   pod 'Expecta'
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
-  - Analytics (3.2.6)
-  - Expecta (1.0.3)
-  - Mixpanel (3.4.9)
-  - OCHamcrest (5.2.0)
-  - OCMockito (3.0.1):
+  - Analytics (3.7.0)
+  - Expecta (1.0.6)
+  - Mixpanel (3.5.0)
+  - OCHamcrest (5.4.0)
+  - OCMockito (3.0.2):
     - OCHamcrest (~> 5.1)
-  - Segment-Mixpanel (1.3.0):
+  - Segment-Mixpanel (1.4.0):
     - Analytics (~> 3.0)
-    - Mixpanel (~> 3.4.7)
+    - Mixpanel (~> 3.5)
   - Specta (1.0.7)
 
 DEPENDENCIES:
   - Expecta
-  - OCMockito
+  - OCMockito (~> 3.0)
   - Segment-Mixpanel (from `../`)
   - Specta
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Analytics
     - Expecta
     - Mixpanel
@@ -30,14 +30,14 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Analytics: ad1c5bdc169866d72afdbc918084d0695010e35a
-  Expecta: 9d1bff6c8b0eeee73a166a2ee898892478927a15
-  Mixpanel: 5aca6e506b34650b96dc759a208513d86650fac7
-  OCHamcrest: 218dc4022a5e928a275771da70c5dbea9f859287
-  OCMockito: 9eee3c61e42f7cb8aa015d66f8cc16849701d973
-  Segment-Mixpanel: 4ff970648d9c49ee0a62a32eec777346316ee7ea
+  Analytics: 77fd5fb102a4a5eedafa2c2b0245ceb7b7c15e45
+  Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
+  Mixpanel: 399997670f5452de026449f9e9ecd52eccbb9ff7
+  OCHamcrest: 5c1d441c5a82fb18ac17c2aeb52ec1a99edb971b
+  OCMockito: 2cb6c2267cbc76537be56281cd47cdb5a7c27541
+  Segment-Mixpanel: 625bb010c65f66acdd976d9db240a420aa67b132
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
-PODFILE CHECKSUM: 507a152874203f544f8656b6532dd0f45dd3c57d
+PODFILE CHECKSUM: 6ff827a80dc2a21042246602306af45cb1c9f2a8
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4

--- a/Example/Segment-Mixpanel/SEGAppDelegate.m
+++ b/Example/Segment-Mixpanel/SEGAppDelegate.m
@@ -7,13 +7,30 @@
 //
 
 #import "SEGAppDelegate.h"
-
+#import <Analytics/SEGAnalytics.h>
+#import <Segment-Mixpanel/SEGMixpanelIntegrationFactory.h>
 
 @implementation SEGAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     // Override point for customization after application launch.
+    
+    // Override point for customization after application launch.
+    [SEGAnalytics debug:YES];
+    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"gnjyuUpq7mZYtLM76mwltoiZcDsFpnfY"];
+    
+    // Add any of your bundled integrations.
+    [config use:[SEGMixpanelIntegrationFactory instance]];
+    
+    [SEGAnalytics setupWithConfiguration:config];
+    
+    [[SEGAnalytics sharedAnalytics] identify:@"segment-fake-tester-Mixpanel"
+                                      traits:@{ @"email": @"tool@fake-segment-tester.com" }];
+    
+    [[SEGAnalytics sharedAnalytics] group:@"testversion1" traits:@{ @"name": @"test group"}];
+    
+    
     return YES;
 }
 

--- a/Example/Segment-Mixpanel/SEGAppDelegate.m
+++ b/Example/Segment-Mixpanel/SEGAppDelegate.m
@@ -18,7 +18,7 @@
     
     // Override point for customization after application launch.
     [SEGAnalytics debug:YES];
-    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"gnjyuUpq7mZYtLM76mwltoiZcDsFpnfY"];
+    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY_HERE"];
     
     // Add any of your bundled integrations.
     [config use:[SEGMixpanelIntegrationFactory instance]];

--- a/Example/Tests/SEGPayloadBuilder.h
+++ b/Example/Tests/SEGPayloadBuilder.h
@@ -23,4 +23,6 @@
 
 + (SEGAliasPayload *)alias:(NSString *)newId;
 
++ (SEGGroupPayload *)group:(NSString *) groupId withTraits:(NSDictionary *)traits;
+
 @end

--- a/Example/Tests/SEGPayloadBuilder.m
+++ b/Example/Tests/SEGPayloadBuilder.m
@@ -41,4 +41,9 @@
     return [[SEGAliasPayload alloc] initWithNewId:newId context:@{} integrations:@{}];
 }
 
++ (SEGGroupPayload *)group:(NSString *)groupId withTraits:(NSDictionary *)traits
+{
+    return [[SEGGroupPayload alloc] initWithGroupId:groupId traits:traits context:@{} integrations:@{}];
+}
+
 @end

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -28,7 +28,8 @@ describe(@"Mixpanel Integration", ^{
         
         integration = [[SEGMixpanelIntegration alloc] initWithSettings:@{
             @"trackAllPages" : @1,
-            @"setAllTraitsByDefault" : @1
+            @"setAllTraitsByDefault" : @1,
+            @"groupIdentifierTraits" : @[@"group_id",@"group_name",@"group_idtest2"]
         } andMixpanel:mixpanel];
     });
 

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -29,7 +29,7 @@ describe(@"Mixpanel Integration", ^{
         integration = [[SEGMixpanelIntegration alloc] initWithSettings:@{
             @"trackAllPages" : @1,
             @"setAllTraitsByDefault" : @1,
-            @"groupIdentifierTraits" : @[@"group_id",@"group_name",@"group_idtest2"]
+            @"groupIdentifierTraits" : @[@"group_id", @"group_name", @"group_idtest2"]
         } andMixpanel:mixpanel];
     });
 
@@ -128,10 +128,20 @@ describe(@"Mixpanel Integration", ^{
     it(@"simple group", ^{
         NSDictionary *groupTraits = @{
                                       @"groupCity" : @"Cairo",
-                                      @"name" : @"mixPanelTest1Group"
+                                      @"group_name" : @"mixPanelTest1Group"
                                       };
         [integration group:[SEGPayloadBuilder group:@"groupTest1" withTraits:groupTraits]];
-        [verify(mixpanel) getGroup:@"mixPanelTest1Group" groupID:@"groupTest1"];
+        
+        NSDictionary *groupIdentifierTraits = integration.settings[@"groupIdentifierTraits"];
+        
+        for (NSString *identifierTrait in groupIdentifierTraits) {
+            NSString *groupIdentifierVal = groupTraits[identifierTrait];
+            if (groupIdentifierVal) {
+                 [verify(mixpanel) getGroup:groupIdentifierVal groupID:@"groupTest1"];
+            }
+           
+        }
+        
     });
     
     it(@"complex group", ^{
@@ -143,7 +153,17 @@ describe(@"Mixpanel Integration", ^{
                                       @"avatar" : @"https://gravatar.com/avatar/f8b72def445675a558fe68b1cb651da1?s=400&d=robohash&r=x"
                                       };
         [integration group:[SEGPayloadBuilder group:@"groupTest1" withTraits:groupTraits]];
-        [verify(mixpanel) getGroup:@"mixPanelTest1Group" groupID:@"groupTest1"];
+        
+        NSDictionary *groupIdentifierTraits = integration.settings[@"groupIdentifierTraits"];
+        
+        for (NSString *identifierTrait in groupIdentifierTraits) {
+            NSString *groupIdentifierVal = groupTraits[identifierTrait];
+            if (groupIdentifierVal) {
+                [verify(mixpanel) getGroup:groupIdentifierVal groupID:@"groupTest1"];
+            }
+            
+        }
+      
     });
 
     it(@"simple group without name", ^{
@@ -151,18 +171,27 @@ describe(@"Mixpanel Integration", ^{
                                       @"groupCity" : @"Cairo"
                                       };
         [integration group:[SEGPayloadBuilder group:@"groupTest2" withTraits:groupTraits]];
-        [verify(mixpanel) getGroup:@"[Segment] Group" groupID:@"groupTest2"];
+        
+        NSDictionary *groupIdentifierTraits = integration.settings[@"groupIdentifierTraits"];
+        
+        for (NSString *identifierTrait in groupIdentifierTraits) {
+            NSString *groupIdentifierVal = groupTraits[identifierTrait];
+             [given([mixpanel getGroup:groupIdentifierVal groupID:@"groupTest2"]) willReturn:nil];
+            
+        }
     });
     
     it(@"simple group setOnce traits", ^{
-        [given([mixpanel getGroup:@"[Segment] Group" groupID:@"groupTest2"]) willReturn:mixpanelGroup];
+        [given([mixpanel getGroup:@"test1" groupID:@"groupTest2"]) willReturn:mixpanelGroup];
         NSDictionary *groupTraits = @{
                                       @"groupCity" : @"Cairo",
-                                      @"groupCount" : @"20"
+                                      @"groupCount" : @"20",
+                                      @"group_id" : @"test1"
                                       };
         [integration group:[SEGPayloadBuilder group:@"groupTest2" withTraits:groupTraits]];
+        
         [verify(mixpanelGroup) setOnce:groupTraits];
-        [verify(mixpanel) getGroup:@"[Segment] Group" groupID:@"groupTest2"];
+        [verify(mixpanel) getGroup:@"test1" groupID:@"groupTest2"];
     });
     
     it(@"alias", ^{

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -132,6 +132,18 @@ describe(@"Mixpanel Integration", ^{
         [integration group:[SEGPayloadBuilder group:@"groupTest1" withTraits:groupTraits]];
         [verify(mixpanel) getGroup:@"mixPanelTest1Group" groupID:@"groupTest1"];
     });
+    
+    it(@"complex group", ^{
+        NSDictionary *groupTraits = @{
+                                      @"groupCity" : @"Alexandria",
+                                      @"name" : @"mixPanelTest1Group",
+                                      @"address": @{@"city": @"Alexandria", @"postalCode": @"22314", @"state":@"Virginia", @"street": @"105 N Union St" },
+                                      @"description": @"Art Center",
+                                      @"avatar" : @"https://gravatar.com/avatar/f8b72def445675a558fe68b1cb651da1?s=400&d=robohash&r=x"
+                                      };
+        [integration group:[SEGPayloadBuilder group:@"groupTest1" withTraits:groupTraits]];
+        [verify(mixpanel) getGroup:@"mixPanelTest1Group" groupID:@"groupTest1"];
+    });
 
     it(@"simple group without name", ^{
         NSDictionary *groupTraits = @{

--- a/Pod/Classes/SEGMixpanelIntegration.m
+++ b/Pod/Classes/SEGMixpanelIntegration.m
@@ -145,22 +145,21 @@
     
     NSString *groupID = payload.groupId;
     NSDictionary *traits = [payload traits];
-    NSString *groupName = traits[@"name"];
     
     NSArray *groupIdentifierProperties = [self.settings objectForKey:@"groupIdentifierTraits"];
     
-    if(groupName == nil || groupName.length == 0 || groupIdentifierProperties.count == 0) {
+    if(!groupID || groupID.length == 0 || groupIdentifierProperties.count == 0) {
         return;
     }
     
     if(traits != nil || traits.count != 0){
         for (NSString *groupIdentiferProperty in groupIdentifierProperties) {
-            [[self.mixpanel getGroup:groupIdentiferProperty groupID:groupID ] setOnce:traits];
+            [[self.mixpanel getGroup:traits[groupIdentiferProperty] groupID:groupID ] setOnce:traits];
         }
     }
     
     for (NSString *groupIdentiferProperty in groupIdentifierProperties) {
-        [self.mixpanel setGroup:groupIdentiferProperty groupID:groupID];
+        [self.mixpanel setGroup:traits[groupIdentiferProperty] groupID:groupID];
         SEGLog(@"[Mixpanel setGroup:%@ groupID:%@]", groupIdentiferProperty, groupID);
     }
     

--- a/Pod/Classes/SEGMixpanelIntegration.m
+++ b/Pod/Classes/SEGMixpanelIntegration.m
@@ -1,5 +1,6 @@
 #import "SEGMixpanelIntegration.h"
 #import <Analytics/SEGAnalyticsUtils.h>
+#import <MixpanelGroup.h>
 
 
 @implementation SEGMixpanelIntegration
@@ -137,6 +138,26 @@
         SEGLog(@"[[Mixpanel sharedInstance] track:'Viewed %@ Screen' properties:%@]", category, payload.properties);
         [self realTrack:event properties:payload.properties];
     }
+}
+
+
+- (void) group:(SEGGroupPayload *)payload {
+    
+    NSString *groupID = payload.groupId;
+    NSDictionary *traits = [payload traits];
+    NSString *groupName = traits[@"name"];
+    
+    if(groupName == nil || groupName.length == 0) {
+        groupName = @"[Segment] Group";
+    }
+    
+    if(traits != nil || traits.count != 0){
+        [[self.mixpanel getGroup:groupName groupID: groupID] setOnce:traits];
+    }
+    
+    [self.mixpanel setGroup:groupName groupID:groupID];
+    SEGLog(@"[Mixpanel setGroup:%@ groupID:%@]", groupName, groupID);
+    
 }
 
 + (NSNumber *)extractRevenue:(NSDictionary *)dictionary withKey:(NSString *)revenueKey

--- a/Pod/Classes/SEGMixpanelIntegration.m
+++ b/Pod/Classes/SEGMixpanelIntegration.m
@@ -147,16 +147,22 @@
     NSDictionary *traits = [payload traits];
     NSString *groupName = traits[@"name"];
     
-    if(groupName == nil || groupName.length == 0) {
-        groupName = @"[Segment] Group";
+    NSArray *groupIdentifierProperties = [self.settings objectForKey:@"groupIdentifierTraits"];
+    
+    if(groupName == nil || groupName.length == 0 || groupIdentifierProperties.count == 0) {
+        return;
     }
     
     if(traits != nil || traits.count != 0){
-        [[self.mixpanel getGroup:groupName groupID: groupID] setOnce:traits];
+        for (NSString *groupIdentiferProperty in groupIdentifierProperties) {
+            [[self.mixpanel getGroup:groupIdentiferProperty groupID:groupID ] setOnce:traits];
+        }
     }
     
-    [self.mixpanel setGroup:groupName groupID:groupID];
-    SEGLog(@"[Mixpanel setGroup:%@ groupID:%@]", groupName, groupID);
+    for (NSString *groupIdentiferProperty in groupIdentifierProperties) {
+        [self.mixpanel setGroup:groupIdentiferProperty groupID:groupID];
+        SEGLog(@"[Mixpanel setGroup:%@ groupID:%@]", groupIdentiferProperty, groupID);
+    }
     
 }
 

--- a/Segment-Mixpanel.podspec
+++ b/Segment-Mixpanel.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics', '~> 3.0'
-  s.dependency 'Mixpanel', '~> 3.4.7'
+  s.dependency 'Mixpanel', '~> 3.5'
 end

--- a/Segment-Mixpanel.podspec
+++ b/Segment-Mixpanel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Segment-Mixpanel"
-  s.version          = "1.5.0"
+  s.version          = "1.4.0"
   s.summary          = "Mixpanel Integration for Segment's analytics-ios library."
 
   s.description      = <<-DESC

--- a/Segment-Mixpanel.podspec
+++ b/Segment-Mixpanel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Segment-Mixpanel"
-  s.version          = "1.4.0"
+  s.version          = "1.5.0"
   s.summary          = "Mixpanel Integration for Segment's analytics-ios library."
 
   s.description      = <<-DESC


### PR DESCRIPTION
**What does this PR do?**

- Update Mixpanel to 3.5
- Add support for groups using Segment Analytics and Mixpanel groups
- Update tests to include groups and setOnce traits.

**Associated JIRA Tickets:**

https://segmentcontractors.atlassian.net/browse/DAND-61